### PR TITLE
Enable multi-order deliveries with new validations

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -39,11 +39,21 @@ class Order(db.Model):
 class Delivery(db.Model):
     __tablename__ = 'deliveries'
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), nullable=False)
+    # Single order_id kept for backward compatibility but optional
+    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), nullable=True)
     truck_id = db.Column(UUID(as_uuid=True), db.ForeignKey('trucks.id'))
     scheduled_date = db.Column(db.Date)
     scheduled_time = db.Column(db.Time)
     status = db.Column(db.String(20), default="Scheduled")
+
+    orders = db.relationship('Order', secondary='delivery_orders', backref='deliveries')
+    order_links = db.relationship('DeliveryOrder', backref='delivery', cascade='all, delete-orphan')
+
+
+class DeliveryOrder(db.Model):
+    __tablename__ = 'delivery_orders'
+    delivery_id = db.Column(UUID(as_uuid=True), db.ForeignKey('deliveries.id'), primary_key=True)
+    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), primary_key=True)
 
 class User(db.Model):
     __tablename__ = 'users'


### PR DESCRIPTION
## Summary
- allow a delivery to contain multiple orders using a new many-to-many model
- validate deliveries: unique order assignment, future dates, avoid truck overbooking and capacity overflow
- expose list of orders in delivery APIs
- update React front-end to support selecting several orders per delivery
- fix missing relationship on Delivery model

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6851b7a3cbb8832b9922e15a426231a3