### PR TITLE
Improve delivery creation defaults and error messages

### DIFF
--- a/app/routes/deliveries.py
+++ b/app/routes/deliveries.py
@@ -127,14 +127,12 @@ def create_delivery():
         )
         db.session.add(history)
         
-        # Add order associations and update order statuses
+        # Add order associations and update order statuses only when delivery is active
         for oid in order_ids:
-            # Create the delivery-order association
             db.session.add(DeliveryOrder(delivery_id=new_delivery.id, order_id=oid))
-            
-            # Update the order status based on delivery status
+
             order = Order.query.get(oid)
-            if order and order.status == 'en attente':
+            if order and order.status == 'en attente' and status in ['programmé', 'en cours', 'Programmé', 'En cours']:
                 order.status = 'planifié'
                 db.session.add(order)
         


### PR DESCRIPTION
## Summary
- default new delivery status to `programmé`
- parse API errors in `DeliveriesPage` for clearer user messages
- only update order status when new delivery is active
- show color for `programmé` status

## Testing
- `pytest -q`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863bf634f14832bad696a3823cf1bf8