### PR TITLE
Track and deduct order quantities when scheduling deliveries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -166,6 +166,8 @@ class DeliveryOrder(db.Model):
     __tablename__ = 'delivery_orders'
     delivery_id = db.Column(UUID(as_uuid=True), db.ForeignKey('deliveries.id'), primary_key=True)
     order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), primary_key=True)
+    quantity = db.Column(db.Float, nullable=False, default=0)
+    quantity_deducted = db.Column(db.Boolean, default=False, nullable=False)
 
 class User(db.Model):
     __tablename__ = 'users'


### PR DESCRIPTION
## Summary
- track quantity per order in `DeliveryOrder`
- expand DB schema update to add new columns
- deduct quantity when deliveries are scheduled and add it back when cancelled
- expose per-order quantities via the deliveries API
- allow choosing delivered quantity on the UI

## Testing
- `python -m py_compile app/models.py app/routes/deliveries.py update_delivery_schema.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68642c5da948832ba5300b9465ef5ee2