### PR TITLE
Track scheduled order amounts in schedule output

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -166,6 +166,8 @@ class DeliveryOrder(db.Model):
     __tablename__ = 'delivery_orders'
     delivery_id = db.Column(UUID(as_uuid=True), db.ForeignKey('deliveries.id'), primary_key=True)
     order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), primary_key=True)
+    quantity = db.Column(db.Float, nullable=False, default=0)
+    quantity_deducted = db.Column(db.Boolean, default=False, nullable=False)
 
 class User(db.Model):
     __tablename__ = 'users'

--- a/frontend/src/components/DeliveriesPage.jsx
+++ b/frontend/src/components/DeliveriesPage.jsx
@@ -197,6 +197,7 @@ export default function DeliveriesPage() {
     destination: '',
     notes: ''
   });
+  const [orderQuantities, setOrderQuantities] = useState({});
   const [formErrors, setFormErrors] = useState({
     order_ids: '',
     truck_id: '',
@@ -387,6 +388,7 @@ export default function DeliveriesPage() {
           destination: delivery.destination || '',
           notes: delivery.notes || ''
         });
+        setOrderQuantities(delivery.order_quantities || {});
         
         // If we have a truck ID, trigger capacity check
         if (delivery.truck_id && orderIds.length > 0) {
@@ -403,6 +405,7 @@ export default function DeliveriesPage() {
           destination: '',
           notes: ''
         });
+        setOrderQuantities({});
         setTruckCapacity({ used: 0, total: 0, exceeded: false });
       }
     } catch (error) {
@@ -415,6 +418,7 @@ export default function DeliveriesPage() {
         scheduled_time: '',
         status: 'programmé'
       });
+      setOrderQuantities({});
       setTruckCapacity({ used: 0, total: 0, exceeded: false });
       setSnackbar({ 
         message: 'Erreur lors du chargement de la livraison', 
@@ -452,19 +456,16 @@ export default function DeliveriesPage() {
 
   // Calculate total quantity of selected orders
   const calculateTotalQuantity = useCallback((orderIds) => {
-    if (!orderIds || !orderIds.length || !dependencies.orders) return 0;
-    
+    if (!orderIds || !orderIds.length) return 0;
+
     const total = orderIds.reduce((sum, orderId) => {
-      const order = dependencies.orders.find(o => o && o.id === orderId);
-      if (!order) return sum;
-      
-      const quantity = parseFloat(order.quantity);
-      return isNaN(quantity) ? sum : sum + quantity;
+      const qty = parseFloat(orderQuantities[orderId]);
+      return isNaN(qty) ? sum : sum + qty;
     }, 0);
     
     console.log('Calculated total quantity:', { orderIds, total });
     return total;
-  }, [dependencies.orders]);
+  }, [orderQuantities]);
 
   // Check if selected orders exceed truck capacity
   const checkTruckCapacity = useCallback((truckId, orderIds) => {
@@ -531,6 +532,19 @@ export default function DeliveriesPage() {
     if (!form.order_ids || form.order_ids.length === 0) {
       errors.order_ids = 'Veuillez sélectionner au moins une commande';
       isValid = false;
+    } else {
+      // Validate quantities for each selected order
+      form.order_ids.forEach(id => {
+        const qty = parseFloat(orderQuantities[id]);
+        const order = dependencies.orders.find(o => o.id === id);
+        if (isNaN(qty) || qty <= 0) {
+          errors.order_ids = 'Quantité invalide pour certaines commandes';
+          isValid = false;
+        } else if (order && qty > parseFloat(order.quantity)) {
+          errors.order_ids = 'Quantité supérieure au disponible';
+          isValid = false;
+        }
+      });
     }
     
     // Validate truck
@@ -733,9 +747,9 @@ export default function DeliveriesPage() {
       // Prepare the payload
       const payload = {
         // Only include order_id if we have orders (for backward compatibility)
-        ...(orderIds.length > 0 && { 
+        ...(orderIds.length > 0 && {
           order_id: orderIds[0],
-          order_ids: orderIds 
+          order_ids: orderIds
         }),
         scheduled_date: formatDateForAPI(form.scheduled_date || new Date()),
         scheduled_time: form.scheduled_time ? formatTimeForAPI(form.scheduled_time) : null,
@@ -743,6 +757,13 @@ export default function DeliveriesPage() {
         destination: form.destination || '',
         notes: form.notes || ''
       };
+
+      if (orderIds.length > 0) {
+        payload.order_quantities = {};
+        orderIds.forEach(id => {
+          payload.order_quantities[id] = parseFloat(orderQuantities[id] || 0);
+        });
+      }
       
       // Handle truck_id - always include it in the payload when updating
       // Convert empty string to null for the backend
@@ -788,6 +809,7 @@ export default function DeliveriesPage() {
         destination: '',
         notes: ''
       });
+      setOrderQuantities({});
       
     } catch (error) {
       console.error('Error saving delivery:', error);
@@ -866,12 +888,29 @@ export default function DeliveriesPage() {
 
   const handleOrderSelect = async (event) => {
     const selectedIds = event.target.value;
-    
+
     // Update form and clear any previous order errors
     setForm(prev => ({
       ...prev,
       order_ids: selectedIds
     }));
+
+    // Initialize quantities for new selections and remove unselected ones
+    setOrderQuantities(prev => {
+      const updated = { ...prev };
+      selectedIds.forEach(id => {
+        if (!(id in updated)) {
+          const order = dependencies.orders?.find(o => o.id === id);
+          updated[id] = order ? order.quantity : '';
+        }
+      });
+      Object.keys(updated).forEach(id => {
+        if (!selectedIds.includes(id)) {
+          delete updated[id];
+        }
+      });
+      return updated;
+    });
     
     // Clear order error if any
     if (formErrors.order_ids) {
@@ -886,6 +925,14 @@ export default function DeliveriesPage() {
       await checkTruckCapacity(form.truck_id, selectedIds);
     } else {
       setTruckCapacity({ used: 0, total: 0, exceeded: false });
+    }
+  };
+
+  const handleQuantityChange = (orderId, value) => {
+    setOrderQuantities(prev => ({ ...prev, [orderId]: value }));
+
+    if (form.truck_id && form.order_ids?.length > 0) {
+      checkTruckCapacity(form.truck_id, form.order_ids);
     }
   };
 
@@ -911,7 +958,7 @@ export default function DeliveriesPage() {
     }
   };
 
-  const getOrderDetails = (orderId) => {
+  const getOrderDetails = (orderId, scheduledQty) => {
     if (orderId == null) return 'ID de commande invalide';
     
     try {
@@ -947,7 +994,7 @@ export default function DeliveriesPage() {
       // Format the order details with date and time
       const details = [
         client?.name || `Client inconnu (ID: ${order.client_id})`,
-        `${order.quantity || 0}T`,
+        `${scheduledQty != null ? scheduledQty : order.quantity || 0}T`,
         product?.name ? `de ${product.name}` : `Produit inconnu (ID: ${order.product_id})`,
         product?.type ? `(${product.type})` : '',
         `- ${formattedDate}`,
@@ -1020,7 +1067,7 @@ export default function DeliveriesPage() {
                   <TableRow key={delivery.id} hover>
                     <TableCell>
                       {delivery.order_ids?.map(orderId => (
-                        <div key={orderId}>{getOrderDetails(orderId)}</div>
+                        <div key={orderId}>{getOrderDetails(orderId, delivery.order_quantities?.[orderId])}</div>
                       )) || 'Aucune commande'}
                     </TableCell>
                     <TableCell>{getTruckDetails(delivery.truck_id)}</TableCell>
@@ -1329,6 +1376,27 @@ export default function DeliveriesPage() {
         </DialogContent>
       </Dialog>
 
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={deleteConfirmation.open}
+        onClose={() => setDeleteConfirmation({ open: false, id: null })}
+      >
+        <DialogTitle>Confirmer la suppression</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Voulez-vous vraiment supprimer cette livraison ?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDeleteConfirmation({ open: false, id: null })} color="inherit" disabled={isDeleting}>
+            Annuler
+          </Button>
+          <Button onClick={handleDeleteConfirm} color="error" variant="contained" disabled={isDeleting}>
+            Supprimer
+          </Button>
+        </DialogActions>
+      </Dialog>
+
       {/* Delivery Form Dialog */}
       <Dialog 
         open={dialogOpen} 
@@ -1489,6 +1557,29 @@ export default function DeliveriesPage() {
                   {`${form.order_ids.length} commande(s) sélectionnée(s)`}
                 </FormHelperText>
               )}
+              {form.order_ids?.map((oid) => {
+                const order = dependencies.orders?.find(o => o.id === oid);
+                if (!order) return null;
+                return (
+                  <Box key={oid} sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
+                    <Typography variant="body2" sx={{ flexGrow: 1 }}>
+                      {order.client?.name || 'Client'} - {order.product?.name || ''}
+                    </Typography>
+                    <TextField
+                      label="Qté"
+                      type="number"
+                      size="small"
+                      value={orderQuantities[oid] ?? ''}
+                      onChange={(e) => handleQuantityChange(oid, e.target.value)}
+                      inputProps={{ min: 0, max: order.quantity, step: 0.1 }}
+                      sx={{ width: 80 }}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      / {order.quantity}t
+                    </Typography>
+                  </Box>
+                );
+              })}
             </FormControl>
 
             <FormControl fullWidth margin="normal">

--- a/frontend/src/components/SchedulePage.jsx
+++ b/frontend/src/components/SchedulePage.jsx
@@ -224,16 +224,18 @@ export default function SchedulePage({ autoRefresh = false }) {
   };
 
   // Helper: Compose delivery rows (with extra info)
-  const renderDeliveries = (orderIds) => {
-    // Build array of enriched deliveries for this truck
-    const deliveries = orderIds.map((orderId, idx) => {
+  const renderDeliveries = (orderEntries) => {
+    // orderEntries may contain just IDs or objects with id/quantity
+    const deliveries = orderEntries.map((entry, idx) => {
+      const orderId = typeof entry === 'string' ? entry : entry.id;
+      const qty = typeof entry === 'object' && entry !== null ? entry.quantity : null;
       const order = orders.find(o => o.id === orderId);
       const client = clients.find(c => c.id === order?.client_id);
       const product = products.find(p => p.id === order?.product_id);
       return {
         idx,
         clientName: client ? client.name : orderId,
-        quantity: order?.quantity,
+        quantity: qty != null ? qty : order?.quantity,
         requestedDate: order?.requested_date,
         requestedTime: order?.requested_time?.slice(0,5) || '-', // "HH:MM"
         product: product ? `${product.name}${product.type ? ` (${product.type})` : ''}` : '',


### PR DESCRIPTION
## Summary
- include quantity in `/schedule/deliveries` response
- show scheduled quantity when rendering planning page

## Testing
- `python -m py_compile app/models.py app/routes/deliveries.py app/routes/schedule.py update_delivery_schema.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68642c5da948832ba5300b9465ef5ee2