### PR TITLE
Fix deletion of deliveries

### DIFF
--- a/app/routes/deliveries.py
+++ b/app/routes/deliveries.py
@@ -607,8 +607,6 @@ def delete_delivery(delivery_id):
                     order.quantity += link.quantity
                     db.session.add(order)
 
-        # Delete the delivery-order associations
-        DeliveryOrder.query.filter_by(delivery_id=delivery.id).delete()
         
         # For each order, check if it should be reverted to 'en attente'
         for order_id in order_ids:


### PR DESCRIPTION
## Summary
- remove direct deletion of delivery_orders in delete route
- avoid StaleDataError when removing a delivery

## Testing
- `npm run lint` *(fails: 22 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686456286a00832b8a3c37c8e94636c0