### PR TITLE
Support external trucks in deliveries

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,54 +4,83 @@ from datetime import datetime
 from sqlalchemy.dialects.postgresql import UUID
 from werkzeug.security import generate_password_hash, check_password_hash
 
+
 class Client(db.Model):
-    __tablename__ = 'clients'
+    __tablename__ = "clients"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(100), nullable=False)
     priority_level = db.Column(db.Integer, nullable=False, default=1)
     contact_info = db.Column(db.String(150))
     address = db.Column(db.String(200))
 
+
 class Product(db.Model):
-    __tablename__ = 'products'
+    __tablename__ = "products"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(50), nullable=False)
     type = db.Column(db.String(50))
 
+
 class Truck(db.Model):
-    __tablename__ = 'trucks'
+    __tablename__ = "trucks"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     plate_number = db.Column(db.String(20), nullable=False)
     capacity = db.Column(db.Float)
     driver_name = db.Column(db.String(100))
 
+
 class Order(db.Model):
-    __tablename__ = 'orders'
+    __tablename__ = "orders"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    client_id = db.Column(UUID(as_uuid=True), db.ForeignKey('clients.id'), nullable=False)
-    product_id = db.Column(UUID(as_uuid=True), db.ForeignKey('products.id'), nullable=False)
+    client_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("clients.id"), nullable=False
+    )
+    product_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("products.id"), nullable=False
+    )
     quantity = db.Column(db.Float, nullable=False)
     requested_date = db.Column(db.Date, nullable=False)
     requested_time = db.Column(db.Time)
     status = db.Column(db.String(20), nullable=False, default="Pending")
-    client = db.relationship('Client', backref='orders')  # <--- add this line!
+    client = db.relationship("Client", backref="orders")  # <--- add this line!
+
 
 class DeliveryHistory(db.Model):
-    __tablename__ = 'delivery_history'
+    __tablename__ = "delivery_history"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    delivery_id = db.Column(UUID(as_uuid=True), db.ForeignKey('deliveries.id', ondelete='CASCADE'), nullable=False)
+    delivery_id = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("deliveries.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     status = db.Column(db.String(20), nullable=False)
-    changed_by = db.Column(UUID(as_uuid=True), db.ForeignKey('users.id', ondelete='SET NULL'), nullable=True)
+    changed_by = db.Column(
+        UUID(as_uuid=True),
+        db.ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     changed_at = db.Column(db.DateTime, nullable=False, server_default=db.func.now())
     notes = db.Column(db.Text, nullable=True)
-    previous_data = db.Column(db.JSON, nullable=True)  # Store previous delivery data as JSON
-    change_type = db.Column(db.String(20), nullable=False, default='status_change')  # status_change, reschedule, etc.
-    
+    previous_data = db.Column(
+        db.JSON, nullable=True
+    )  # Store previous delivery data as JSON
+    change_type = db.Column(
+        db.String(20), nullable=False, default="status_change"
+    )  # status_change, reschedule, etc.
+
     # Relationships
-    user = db.relationship('User')
-    
+    user = db.relationship("User")
+
     @classmethod
-    def log_change(cls, delivery, changed_by_id, status, notes=None, previous_data=None, change_type='status_change'):
+    def log_change(
+        cls,
+        delivery,
+        changed_by_id,
+        status,
+        notes=None,
+        previous_data=None,
+        change_type="status_change",
+    ):
         """Helper method to log delivery changes"""
         history = cls(
             delivery_id=delivery.id,
@@ -59,17 +88,20 @@ class DeliveryHistory(db.Model):
             changed_by=changed_by_id,
             notes=notes,
             previous_data=previous_data,
-            change_type=change_type
+            change_type=change_type,
         )
         db.session.add(history)
         return history
 
+
 class Delivery(db.Model):
-    __tablename__ = 'deliveries'
+    __tablename__ = "deliveries"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     # Single order_id kept for backward compatibility but optional
-    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), nullable=True)
-    truck_id = db.Column(UUID(as_uuid=True), db.ForeignKey('trucks.id'))
+    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey("orders.id"), nullable=True)
+    truck_id = db.Column(UUID(as_uuid=True), db.ForeignKey("trucks.id"))
+    external_truck_label = db.Column(db.String(100), nullable=True)
+    is_external = db.Column(db.Boolean, default=False, nullable=False)
     scheduled_date = db.Column(db.Date)
     scheduled_time = db.Column(db.Time)
     status = db.Column(db.String(20), default="Scheduled")
@@ -77,100 +109,120 @@ class Delivery(db.Model):
     notes = db.Column(db.Text, nullable=True)
     delayed = db.Column(db.Boolean, default=False, nullable=False)
     last_updated = db.Column(db.DateTime, onupdate=db.func.now())
-    
+
     # Relationships
-    orders = db.relationship('Order', secondary='delivery_orders', backref='deliveries')
-    order_links = db.relationship('DeliveryOrder', backref='delivery', cascade='all, delete-orphan')
-    history = db.relationship('DeliveryHistory', backref='delivery', cascade='all, delete-orphan', 
-                             order_by='desc(DeliveryHistory.changed_at)')
-    truck = db.relationship('Truck')
-    
+    orders = db.relationship("Order", secondary="delivery_orders", backref="deliveries")
+    order_links = db.relationship(
+        "DeliveryOrder", backref="delivery", cascade="all, delete-orphan"
+    )
+    history = db.relationship(
+        "DeliveryHistory",
+        backref="delivery",
+        cascade="all, delete-orphan",
+        order_by="desc(DeliveryHistory.changed_at)",
+    )
+    truck = db.relationship("Truck")
+
     def log_status_change(self, user_id, new_status, notes=None, previous_data=None):
         """Log a status change in the delivery history"""
-        change_type = 'status_change'
-        if previous_data and any(field in previous_data for field in ['scheduled_date', 'scheduled_time', 'truck_id']):
-            change_type = 'reschedule'
-            
+        change_type = "status_change"
+        if previous_data and any(
+            field in previous_data
+            for field in ["scheduled_date", "scheduled_time", "truck_id"]
+        ):
+            change_type = "reschedule"
+
         return DeliveryHistory.log_change(
             delivery=self,
             changed_by_id=user_id,
             status=new_status,
             notes=notes,
             previous_data=previous_data,
-            change_type=change_type
+            change_type=change_type,
         )
-    
+
     def update_status(self, new_status, user_id, notes=None):
         """Update delivery status and log the change"""
         if self.status == new_status:
             return False
-            
+
         previous_status = self.status
         self.status = new_status
-        
+
         # Log the status change
-        self.log_status_change(user_id, new_status, notes, {'status': previous_status})
-        
+        self.log_status_change(user_id, new_status, notes, {"status": previous_status})
+
         # Update related orders status if needed
         self._update_related_orders_status()
-        
+
         return True
-    
-    def reschedule(self, new_date=None, new_time=None, truck_id=None, user_id=None, notes=None):
+
+    def reschedule(
+        self, new_date=None, new_time=None, truck_id=None, user_id=None, notes=None
+    ):
         """Reschedule a delivery and log the changes"""
         changes = {}
-        
+
         if new_date and new_date != self.scheduled_date:
-            changes['scheduled_date'] = str(self.scheduled_date) if self.scheduled_date else None
+            changes["scheduled_date"] = (
+                str(self.scheduled_date) if self.scheduled_date else None
+            )
             self.scheduled_date = new_date
-            
+
         if new_time and new_time != self.scheduled_time:
-            changes['scheduled_time'] = str(self.scheduled_time) if self.scheduled_time else None
+            changes["scheduled_time"] = (
+                str(self.scheduled_time) if self.scheduled_time else None
+            )
             self.scheduled_time = new_time
-            
+
         if truck_id and truck_id != self.truck_id:
-            changes['truck_id'] = str(self.truck_id) if self.truck_id else None
+            changes["truck_id"] = str(self.truck_id) if self.truck_id else None
             self.truck_id = truck_id
-            
+
         if not changes:
             return False  # No changes made
-            
+
         # Log the reschedule
         change_notes = notes or "Delivery rescheduled"
         self.log_status_change(
             user_id=user_id,
             new_status=self.status,
             notes=change_notes,
-            previous_data=changes
+            previous_data=changes,
         )
-        
+
         return True
-    
+
     def _update_related_orders_status(self):
         """Update status of related orders based on delivery status"""
         if not self.orders:
             return
-            
+
         for order in self.orders:
-            if self.status.lower() == 'annulée':
-                order.status = 'annulée'
-            elif self.status.lower() == 'en cours':
-                if order.status.lower() in ['planifié', 'en attente']:
-                    order.status = 'en cours'
-            elif self.status.lower() == 'livrée':
-                order.status = 'livrée'
+            if self.status.lower() == "annulée":
+                order.status = "annulée"
+            elif self.status.lower() == "en cours":
+                if order.status.lower() in ["planifié", "en attente"]:
+                    order.status = "en cours"
+            elif self.status.lower() == "livrée":
+                order.status = "livrée"
             db.session.add(order)
 
 
 class DeliveryOrder(db.Model):
-    __tablename__ = 'delivery_orders'
-    delivery_id = db.Column(UUID(as_uuid=True), db.ForeignKey('deliveries.id'), primary_key=True)
-    order_id = db.Column(UUID(as_uuid=True), db.ForeignKey('orders.id'), primary_key=True)
+    __tablename__ = "delivery_orders"
+    delivery_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("deliveries.id"), primary_key=True
+    )
+    order_id = db.Column(
+        UUID(as_uuid=True), db.ForeignKey("orders.id"), primary_key=True
+    )
     quantity = db.Column(db.Float, nullable=False, default=0)
     quantity_deducted = db.Column(db.Boolean, default=False, nullable=False)
 
+
 class User(db.Model):
-    __tablename__ = 'users'
+    __tablename__ = "users"
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(200), nullable=False)

--- a/app/routes/deliveries.py
+++ b/app/routes/deliveries.py
@@ -8,30 +8,31 @@ from datetime import datetime, timedelta
 from sqlalchemy import desc, func
 
 # Status strings used for cancelled deliveries (masculine/feminine forms)
-CANCELLED_STATUSES = ['annulée', 'annulé']
+CANCELLED_STATUSES = ["annulée", "annulé"]
 
 
-bp = Blueprint('deliveries', __name__, url_prefix='/deliveries')
+bp = Blueprint("deliveries", __name__, url_prefix="/deliveries")
 bp.strict_slashes = False
 
-@bp.route('', methods=['POST', 'OPTIONS'])
+
+@bp.route("", methods=["POST", "OPTIONS"])
 @jwt_required()
 def create_delivery():
-    if request.method == 'OPTIONS':
-        return '', 200
+    if request.method == "OPTIONS":
+        return "", 200
     try:
         logging.debug(f"Request headers: {dict(request.headers)}")
         identity = get_jwt_identity()
         logging.debug(f"JWT identity: {identity}")
         data = request.get_json(force=True, silent=True)
         logging.debug(f"Received data: {data}")
-        
+
         # Accept either a single order_id or a list of order_ids
         order_ids = []
-        if 'order_ids' in data:
-            order_ids = data['order_ids']
-        elif 'order_id' in data:
-            order_ids = [data['order_id']]
+        if "order_ids" in data:
+            order_ids = data["order_ids"]
+        elif "order_id" in data:
+            order_ids = [data["order_id"]]
         else:
             return jsonify({"error": "order_ids required"}), 400
 
@@ -46,28 +47,44 @@ def create_delivery():
                 conv_ids.append(oid)
         order_ids = conv_ids
 
-        order_quantities = data.get('order_quantities', {})
+        order_quantities = data.get("order_quantities", {})
 
-        if 'truck_id' in data and isinstance(data['truck_id'], str):
+        if (
+            "truck_id" in data
+            and isinstance(data["truck_id"], str)
+            and data["truck_id"]
+        ):
             try:
-                data['truck_id'] = uuid.UUID(data['truck_id'])
+                data["truck_id"] = uuid.UUID(data["truck_id"])
             except Exception:
                 return jsonify({"error": "Invalid truck_id UUID"}), 400
 
+        is_external = bool(data.get("is_external"))
+        external_label = data.get("external_truck_label")
+        if is_external:
+            data["truck_id"] = None
+
         # Convert scheduled_date to date
-        if 'scheduled_date' in data and isinstance(data['scheduled_date'], str):
+        if "scheduled_date" in data and isinstance(data["scheduled_date"], str):
             try:
-                data['scheduled_date'] = datetime.strptime(data['scheduled_date'], '%Y-%m-%d').date()
+                data["scheduled_date"] = datetime.strptime(
+                    data["scheduled_date"], "%Y-%m-%d"
+                ).date()
             except Exception:
-                return jsonify({"error": "Invalid date format, should be YYYY-MM-DD"}), 400
+                return (
+                    jsonify({"error": "Invalid date format, should be YYYY-MM-DD"}),
+                    400,
+                )
 
         # Convert scheduled_time to time
-        if 'scheduled_time' in data and isinstance(data['scheduled_time'], str):
+        if "scheduled_time" in data and isinstance(data["scheduled_time"], str):
             try:
-                data['scheduled_time'] = datetime.strptime(data['scheduled_time'], '%H:%M').time()
+                data["scheduled_time"] = datetime.strptime(
+                    data["scheduled_time"], "%H:%M"
+                ).time()
             except Exception:
                 return jsonify({"error": "Invalid time format, should be HH:MM"}), 400
-        
+
         # ===== Business validations =====
         # 1. Orders must not already be scheduled
         for oid in order_ids:
@@ -78,25 +95,26 @@ def create_delivery():
                 return jsonify({"error": "Order already scheduled"}), 400
 
         # 2. Date/time must be in the future
-        if data.get('scheduled_date'):
+        if data.get("scheduled_date"):
             sched_dt = datetime.combine(
-                data['scheduled_date'],
-                data.get('scheduled_time') or datetime.min.time()
+                data["scheduled_date"],
+                data.get("scheduled_time") or datetime.min.time(),
             )
             if sched_dt <= datetime.now():
                 return jsonify({"error": "Delivery must be in the future"}), 400
 
-        # 3. Truck/time slot must be free
-        existing_deliv = Delivery.query.filter_by(
-            truck_id=data['truck_id'],
-            scheduled_date=data.get('scheduled_date'),
-            scheduled_time=data.get('scheduled_time')
-        ).first()
-        if existing_deliv:
-            return jsonify({"error": "Truck already booked for this time"}), 400
+        # 3. Truck/time slot must be free for internal trucks
+        if data.get("truck_id"):
+            existing_deliv = Delivery.query.filter_by(
+                truck_id=data["truck_id"],
+                scheduled_date=data.get("scheduled_date"),
+                scheduled_time=data.get("scheduled_time"),
+            ).first()
+            if existing_deliv:
+                return jsonify({"error": "Truck already booked for this time"}), 400
 
-        # 4. Respect truck capacity
-        truck = Truck.query.get(data['truck_id'])
+        # 4. Respect truck capacity for internal trucks
+        truck = Truck.query.get(data["truck_id"]) if data.get("truck_id") else None
         total_qty = 0
         for oid in order_ids:
             order = Order.query.get(oid)
@@ -114,35 +132,37 @@ def create_delivery():
                 current_user_id = uuid.UUID(current_user_id)
         except (ValueError, AttributeError):
             return jsonify({"error": "Invalid user ID format"}), 400
-        
+
         # Set default status if not provided and normalize case
-        status = data.get('status', 'programmé')
+        status = data.get("status", "programmé")
         if status:
             status = status.lower()
-        
+
         # Create the delivery
         new_delivery = Delivery(
-            truck_id=data['truck_id'],
-            scheduled_date=data.get('scheduled_date'),
-            scheduled_time=data.get('scheduled_time'),
+            truck_id=data.get("truck_id"),
+            external_truck_label=external_label if is_external else None,
+            is_external=is_external,
+            scheduled_date=data.get("scheduled_date"),
+            scheduled_time=data.get("scheduled_time"),
             status=status,
-            destination=data.get('destination', ''),
-            notes=data.get('notes', '')
+            destination=data.get("destination", ""),
+            notes=data.get("notes", ""),
         )
         db.session.add(new_delivery)
         db.session.flush()  # Get the ID for the new delivery
-        
+
         # Add initial status to history
         history = DeliveryHistory(
             delivery_id=new_delivery.id,
             status=status,
             changed_by=current_user_id,  # This is now a UUID object
-            notes="Initial status"
+            notes="Initial status",
         )
         db.session.add(history)
-        
+
         # Add order associations and handle quantity deductions
-        active_statuses = ['programmé', 'en cours']
+        active_statuses = ["programmé", "en cours"]
         for oid in order_ids:
             order = Order.query.get(oid)
             if not order:
@@ -158,112 +178,143 @@ def create_delivery():
                 return jsonify({"error": f"Invalid quantity for order {oid}"}), 400
 
             if qty > order.quantity:
-                return jsonify({"error": f"Quantity {qty} exceeds remaining for order {oid}"}), 400
+                return (
+                    jsonify(
+                        {"error": f"Quantity {qty} exceeds remaining for order {oid}"}
+                    ),
+                    400,
+                )
 
-            link = DeliveryOrder(delivery_id=new_delivery.id, order_id=oid, quantity=qty)
+            link = DeliveryOrder(
+                delivery_id=new_delivery.id, order_id=oid, quantity=qty
+            )
 
             if status in active_statuses:
                 order.quantity -= qty
                 link.quantity_deducted = True
-                if order.status and order.status.lower() == 'en attente':
-                    order.status = 'planifié'
+                if order.status and order.status.lower() == "en attente":
+                    order.status = "planifié"
                 db.session.add(order)
 
             db.session.add(link)
-        
+
         db.session.commit()
         logging.info(f"Delivery created with ID: {new_delivery.id}")
-        
+
         # Return the created delivery with its history
         delivery_data = {
-            'id': str(new_delivery.id),
-            'status': new_delivery.status,
-            'delayed': new_delivery.delayed,
-            'order_quantities': {str(link.order_id): link.quantity for link in new_delivery.order_links},
-            'history': [{
-                'id': history.id,
-                'status': history.status,
-                'changed_at': history.changed_at.isoformat(),
-                'changed_by': None,  # Will be loaded if include_history=true
-                'notes': history.notes
-            }]
+            "id": str(new_delivery.id),
+            "status": new_delivery.status,
+            "is_external": new_delivery.is_external,
+            "external_truck_label": new_delivery.external_truck_label,
+            "delayed": new_delivery.delayed,
+            "order_quantities": {
+                str(link.order_id): link.quantity for link in new_delivery.order_links
+            },
+            "history": [
+                {
+                    "id": history.id,
+                    "status": history.status,
+                    "changed_at": history.changed_at.isoformat(),
+                    "changed_by": None,  # Will be loaded if include_history=true
+                    "notes": history.notes,
+                }
+            ],
         }
-        
+
         return jsonify({"message": "Delivery created", "delivery": delivery_data}), 201
     except Exception as e:
         logging.exception("Exception occurred while creating delivery")
         return jsonify({"error": "Server error", "details": str(e)}), 500
 
-@bp.route('', methods=['GET', 'OPTIONS'])
+
+@bp.route("", methods=["GET", "OPTIONS"])
 @jwt_required()
 def get_deliveries():
-    if request.method == 'OPTIONS':
-        return '', 200
+    if request.method == "OPTIONS":
+        return "", 200
     try:
         logging.debug(f"Request headers: {dict(request.headers)}")
         identity = get_jwt_identity()
         logging.debug(f"JWT identity: {identity}")
-        
+
         # Get the include_history parameter
-        include_history = request.args.get('include_history', 'false').lower() == 'true'
-        
+        include_history = request.args.get("include_history", "false").lower() == "true"
+
         # Base query
         query = Delivery.query
-        
+
         # If history is requested, join with DeliveryHistory and User
         if include_history:
             from sqlalchemy.orm import joinedload
+
             query = query.options(
                 joinedload(Delivery.history).joinedload(DeliveryHistory.user)
             )
-        
+
         # Execute query
         deliveries = query.all()
         result = []
-        
+
         for delivery in deliveries:
             # Get all order IDs for this delivery
             order_ids = [str(o.id) for o in delivery.orders]
             if delivery.order_id:
                 order_ids.append(str(delivery.order_id))
-            
+
             # Build delivery data
             delivery_data = {
-                'id': str(delivery.id),
-                'order_ids': list(set(order_ids)),  # Remove duplicates if any
-                'truck_id': str(delivery.truck_id) if delivery.truck_id else None,
-                'scheduled_date': delivery.scheduled_date.isoformat() if delivery.scheduled_date else None,
-                'scheduled_time': str(delivery.scheduled_time) if delivery.scheduled_time else None,
-                'status': delivery.status,
-                'destination': delivery.destination,
-                'notes': delivery.notes,
-                'delayed': delivery.delayed,
-                'order_quantities': {str(l.order_id): l.quantity for l in delivery.order_links}
+                "id": str(delivery.id),
+                "order_ids": list(set(order_ids)),  # Remove duplicates if any
+                "truck_id": str(delivery.truck_id) if delivery.truck_id else None,
+                "is_external": delivery.is_external,
+                "external_truck_label": delivery.external_truck_label,
+                "scheduled_date": (
+                    delivery.scheduled_date.isoformat()
+                    if delivery.scheduled_date
+                    else None
+                ),
+                "scheduled_time": (
+                    str(delivery.scheduled_time) if delivery.scheduled_time else None
+                ),
+                "status": delivery.status,
+                "destination": delivery.destination,
+                "notes": delivery.notes,
+                "delayed": delivery.delayed,
+                "order_quantities": {
+                    str(l.order_id): l.quantity for l in delivery.order_links
+                },
             }
-            
+
             # Add history if requested
-            if include_history and hasattr(delivery, 'history'):
-                delivery_data['history'] = [{
-                    'id': str(h.id),
-                    'status': h.status,
-                    'changed_at': h.changed_at.isoformat(),
-                    'changed_by': h.user.username if h.user else None,
-                    'notes': h.notes
-                } for h in sorted(delivery.history, key=lambda x: x.changed_at, reverse=True)]
-            
+            if include_history and hasattr(delivery, "history"):
+                delivery_data["history"] = [
+                    {
+                        "id": str(h.id),
+                        "status": h.status,
+                        "changed_at": h.changed_at.isoformat(),
+                        "changed_by": h.user.username if h.user else None,
+                        "notes": h.notes,
+                    }
+                    for h in sorted(
+                        delivery.history, key=lambda x: x.changed_at, reverse=True
+                    )
+                ]
+
             result.append(delivery_data)
-            
+
         return jsonify(result), 200
     except Exception as e:
         logging.exception("Exception occurred while getting deliveries")
         return jsonify({"error": "Server error", "details": str(e)}), 500
 
-@bp.route('/<delivery_id>', methods=['PUT', 'OPTIONS'])
+
+@bp.route("/<delivery_id>", methods=["PUT", "OPTIONS"])
 @jwt_required()
 def update_delivery(delivery_id):
-    if request.method == 'OPTIONS':
-        return '', 200
-        
+    if request.method == "OPTIONS":
+        return "", 200
+
     # 1) Parse and validate the URL param
     try:
         delivery_uuid = uuid.UUID(delivery_id)
@@ -276,16 +327,18 @@ def update_delivery(delivery_id):
 
     # 2) Load JSON and drop any unexpected id
     data = request.get_json(force=True, silent=True) or {}
-    data.pop('id', None)
-    
+    data.pop("id", None)
+
     # Store original data for history and change detection
     original_data = {
-        'scheduled_date': delivery.scheduled_date,
-        'scheduled_time': delivery.scheduled_time,
-        'truck_id': delivery.truck_id,
-        'status': delivery.status,
-        'destination': delivery.destination,
-        'notes': delivery.notes
+        "scheduled_date": delivery.scheduled_date,
+        "scheduled_time": delivery.scheduled_time,
+        "truck_id": delivery.truck_id,
+        "is_external": delivery.is_external,
+        "external_truck_label": delivery.external_truck_label,
+        "status": delivery.status,
+        "destination": delivery.destination,
+        "notes": delivery.notes,
     }
 
     # 3) Get current user and validate
@@ -295,42 +348,45 @@ def update_delivery(delivery_id):
             current_user_id = uuid.UUID(current_user_id)
     except (ValueError, AttributeError):
         return jsonify({"error": "Invalid user ID format"}), 400
-        
+
     # Check for rescheduling (date, time, or truck changes)
     is_rescheduling = False
     reschedule_details = []
-    
+
     # 4) Handle status changes and log history
     status_changed = False
-    prev_status = delivery.status.lower() if delivery.status else ''
-    new_status_raw = data.get('status')
+    prev_status = delivery.status.lower() if delivery.status else ""
+    new_status_raw = data.get("status")
     new_status = new_status_raw.lower() if new_status_raw else None
 
     if new_status is not None and new_status != prev_status:
         # Log the status change in history
         change_notes = []
-        
+
         # Add status change note
         status_note = f"Statut modifié de {delivery.status} à {new_status}"
         change_notes.append(status_note)
-        
+
         # Check for special status transitions
-        if new_status in CANCELLED_STATUSES and prev_status in ['programmé', 'en cours']:
+        if new_status in CANCELLED_STATUSES and prev_status in [
+            "programmé",
+            "en cours",
+        ]:
             delivery.delayed = True
             change_notes.append("Livraison marquée comme retardée")
-            
+
         # Create history entry
         history = DeliveryHistory(
             delivery_id=delivery.id,
             status=new_status,
             changed_by=current_user_id,
-            change_type='status_change',
+            change_type="status_change",
             previous_data={
-                'status': delivery.status,
-                'changed_at': datetime.utcnow().isoformat(),
-                'changed_by': str(current_user_id)
+                "status": delivery.status,
+                "changed_at": datetime.utcnow().isoformat(),
+                "changed_by": str(current_user_id),
             },
-            notes=' | '.join(change_notes)
+            notes=" | ".join(change_notes),
         )
         db.session.add(history)
 
@@ -339,7 +395,7 @@ def update_delivery(delivery_id):
         status_changed = True
 
         # Adjust order quantities based on new status
-        active_statuses = ['programmé', 'en cours']
+        active_statuses = ["programmé", "en cours"]
         if new_status in active_statuses and prev_status not in active_statuses:
             for link in delivery.order_links:
                 if not link.quantity_deducted:
@@ -347,8 +403,8 @@ def update_delivery(delivery_id):
                     if order and link.quantity <= order.quantity:
                         order.quantity -= link.quantity
                         link.quantity_deducted = True
-                        if order.status and order.status.lower() == 'en attente':
-                            order.status = 'planifié'
+                        if order.status and order.status.lower() == "en attente":
+                            order.status = "planifié"
                         db.session.add(order)
         elif new_status in CANCELLED_STATUSES and prev_status in active_statuses:
             for link in delivery.order_links:
@@ -358,38 +414,50 @@ def update_delivery(delivery_id):
                         order.quantity += link.quantity
                         link.quantity_deducted = False
                         db.session.add(order)
-    
-    # Handle other simple scalar fields
-    if 'destination' in data:
-        delivery.destination = data['destination'] or ''
-    if 'notes' in data:
-        delivery.notes = data['notes'] or ''
 
-    # 4) Convert and set truck_id if provided
-    if 'truck_id' in data:
-        if data['truck_id']:
+    # Handle other simple scalar fields
+    if "destination" in data:
+        delivery.destination = data["destination"] or ""
+    if "notes" in data:
+        delivery.notes = data["notes"] or ""
+
+    # 4) Convert and set truck/external fields if provided
+    if "is_external" in data:
+        delivery.is_external = bool(data["is_external"])
+
+    if "external_truck_label" in data:
+        delivery.external_truck_label = data.get("external_truck_label")
+
+    if "truck_id" in data:
+        if data["truck_id"]:
             try:
-                delivery.truck_id = uuid.UUID(data['truck_id'])
+                delivery.truck_id = uuid.UUID(data["truck_id"])
             except ValueError:
                 return jsonify({"error": "Invalid truck_id UUID"}), 400
         else:
             delivery.truck_id = None
 
+    if delivery.is_external:
+        delivery.truck_id = None
+
     # 5) Convert & set scheduled_date/time
-    if 'scheduled_date' in data:
-        sd = data['scheduled_date']
+    if "scheduled_date" in data:
+        sd = data["scheduled_date"]
         if sd:
             try:
-                delivery.scheduled_date = datetime.strptime(sd, '%Y-%m-%d').date()
+                delivery.scheduled_date = datetime.strptime(sd, "%Y-%m-%d").date()
             except ValueError:
-                return jsonify({"error": "Invalid date format, should be YYYY-MM-DD"}), 400
+                return (
+                    jsonify({"error": "Invalid date format, should be YYYY-MM-DD"}),
+                    400,
+                )
         else:
             delivery.scheduled_date = None
 
-    if 'scheduled_time' in data:
-        st = data['scheduled_time']
+    if "scheduled_time" in data:
+        st = data["scheduled_time"]
         if st:
-            fmt = '%H:%M:%S' if len(st) == 8 else '%H:%M'
+            fmt = "%H:%M:%S" if len(st) == 8 else "%H:%M"
             try:
                 delivery.scheduled_time = datetime.strptime(st, fmt).time()
             except ValueError:
@@ -398,16 +466,16 @@ def update_delivery(delivery_id):
             delivery.scheduled_time = None
 
     # 6) Orders many-to-many: rebuild only if user sent order_ids
-    if 'order_ids' in data:
+    if "order_ids" in data:
         conv_ids = []
-        for oid in data['order_ids'] or []:
+        for oid in data["order_ids"] or []:
             try:
                 conv_ids.append(uuid.UUID(oid))
             except (ValueError, TypeError):
                 return jsonify({"error": f"Invalid order ID format: {oid}"}), 400
 
-        order_quantities = data.get('order_quantities', {})
-        active_statuses = ['programmé', 'en cours']
+        order_quantities = data.get("order_quantities", {})
+        active_statuses = ["programmé", "en cours"]
 
         # rollback quantities for existing links if deducted
         existing_links = DeliveryOrder.query.filter_by(delivery_id=delivery.id).all()
@@ -435,69 +503,128 @@ def update_delivery(delivery_id):
                 return jsonify({"error": f"Invalid quantity for order {oid}"}), 400
 
             if qty > order.quantity:
-                return jsonify({"error": f"Quantity {qty} exceeds remaining for order {oid}"}), 400
+                return (
+                    jsonify(
+                        {"error": f"Quantity {qty} exceeds remaining for order {oid}"}
+                    ),
+                    400,
+                )
 
             link = DeliveryOrder(delivery_id=delivery.id, order_id=oid, quantity=qty)
             if (new_status or prev_status) in active_statuses:
                 order.quantity -= qty
                 link.quantity_deducted = True
-                if order.status and order.status.lower() == 'en attente':
-                    order.status = 'planifié'
+                if order.status and order.status.lower() == "en attente":
+                    order.status = "planifié"
                 db.session.add(order)
 
             db.session.add(link)
 
     # 7) Check for rescheduling (date, time, or truck changes)
-    if any(field in data for field in ['scheduled_date', 'scheduled_time', 'truck_id']):
+    if any(
+        field in data
+        for field in [
+            "scheduled_date",
+            "scheduled_time",
+            "truck_id",
+            "is_external",
+            "external_truck_label",
+        ]
+    ):
         # Check what exactly changed
         changes = []
-        
-        if 'scheduled_date' in data and str(original_data['scheduled_date']) != str(delivery.scheduled_date):
-            changes.append(f"Date: {original_data['scheduled_date']} → {delivery.scheduled_date}")
+
+        if "scheduled_date" in data and str(original_data["scheduled_date"]) != str(
+            delivery.scheduled_date
+        ):
+            changes.append(
+                f"Date: {original_data['scheduled_date']} → {delivery.scheduled_date}"
+            )
             is_rescheduling = True
-            
-        if 'scheduled_time' in data and str(original_data.get('scheduled_time') or '') != str(delivery.scheduled_time or ''):
-            changes.append(f"Heure: {original_data.get('scheduled_time')} → {delivery.scheduled_time}")
+
+        if "scheduled_time" in data and str(
+            original_data.get("scheduled_time") or ""
+        ) != str(delivery.scheduled_time or ""):
+            changes.append(
+                f"Heure: {original_data.get('scheduled_time')} → {delivery.scheduled_time}"
+            )
             is_rescheduling = True
-            
-        if 'truck_id' in data and str(original_data.get('truck_id') or '') != str(delivery.truck_id or ''):
-            old_truck = Truck.query.get(original_data.get('truck_id'))
-            new_truck = Truck.query.get(delivery.truck_id) if delivery.truck_id else None
-            changes.append(f"Camion: {getattr(old_truck, 'plate_number', 'Aucun')} → {getattr(new_truck, 'plate_number', 'Aucun')}")
+
+        if "truck_id" in data and str(original_data.get("truck_id") or "") != str(
+            delivery.truck_id or ""
+        ):
+            old_truck = Truck.query.get(original_data.get("truck_id"))
+            new_truck = (
+                Truck.query.get(delivery.truck_id) if delivery.truck_id else None
+            )
+            changes.append(
+                f"Camion: {getattr(old_truck, 'plate_number', 'Aucun')} → {getattr(new_truck, 'plate_number', 'Aucun')}"
+            )
             is_rescheduling = True
-        
+
+        if (
+            "is_external" in data
+            and bool(original_data.get("is_external")) != delivery.is_external
+        ):
+            changes.append("Type de camion modifié")
+            is_rescheduling = True
+        if "external_truck_label" in data and str(
+            original_data.get("external_truck_label") or ""
+        ) != str(delivery.external_truck_label or ""):
+            changes.append("Libellé camion externe modifié")
+            is_rescheduling = True
+
         if is_rescheduling and changes:
             # Create a history entry for the reschedule
             history = DeliveryHistory(
                 delivery_id=delivery.id,
                 status=delivery.status,
                 changed_by=current_user_id,
-                change_type='reschedule',
+                change_type="reschedule",
                 previous_data={
-                    'scheduled_date': original_data['scheduled_date'].isoformat() if original_data['scheduled_date'] else None,
-                    'scheduled_time': str(original_data['scheduled_time']) if original_data['scheduled_time'] else None,
-                    'truck_id': str(original_data['truck_id']) if original_data['truck_id'] else None,
-                    'changed_at': datetime.utcnow().isoformat(),
-                    'changed_by': str(current_user_id)
+                    "scheduled_date": (
+                        original_data["scheduled_date"].isoformat()
+                        if original_data["scheduled_date"]
+                        else None
+                    ),
+                    "scheduled_time": (
+                        str(original_data["scheduled_time"])
+                        if original_data["scheduled_time"]
+                        else None
+                    ),
+                    "truck_id": (
+                        str(original_data["truck_id"])
+                        if original_data["truck_id"]
+                        else None
+                    ),
+                    "is_external": original_data["is_external"],
+                    "external_truck_label": original_data["external_truck_label"],
+                    "changed_at": datetime.utcnow().isoformat(),
+                    "changed_by": str(current_user_id),
                 },
-                notes="Reprogrammation de la livraison: " + ", ".join(changes)
+                notes="Reprogrammation de la livraison: " + ", ".join(changes),
             )
             db.session.add(history)
-            
+
             # If rescheduling to a future date and status was delayed, clear the delay
-            if delivery.delayed and delivery.scheduled_date and delivery.scheduled_date >= datetime.utcnow().date():
+            if (
+                delivery.delayed
+                and delivery.scheduled_date
+                and delivery.scheduled_date >= datetime.utcnow().date()
+            ):
                 delivery.delayed = False
                 history.notes += " | Retard annulé (nouvelle date dans le futur)"
-    
+
     # 8) Business checks: future date & unique slot
     if delivery.scheduled_date:
         combined = datetime.combine(
-            delivery.scheduled_date,
-            delivery.scheduled_time or datetime.min.time()
+            delivery.scheduled_date, delivery.scheduled_time or datetime.min.time()
         )
         now = datetime.now()
-        
-        if combined <= now and not (status_changed and delivery.status in CANCELLED_STATUSES):
+
+        if combined <= now and not (
+            status_changed and delivery.status in CANCELLED_STATUSES
+        ):
             # If we're updating to a past date, set the delayed flag if not already set
             if not delivery.delayed:
                 delivery.delayed = True
@@ -506,22 +633,27 @@ def update_delivery(delivery_id):
                     delivery_id=delivery.id,
                     status=delivery.status,
                     changed_by=current_user_id,
-                    change_type='delay',
+                    change_type="delay",
                     notes="Livraison marquée comme retardée (date/heure dans le passé)",
                     previous_data={
-                        'delayed': False,
-                        'changed_at': datetime.utcnow().isoformat(),
-                        'changed_by': str(current_user_id)
-                    }
+                        "delayed": False,
+                        "changed_at": datetime.utcnow().isoformat(),
+                        "changed_by": str(current_user_id),
+                    },
                 )
                 db.session.add(history)
-            
+
             # Only block if this is not a status update to a cancelled status
             if not (status_changed and delivery.status in CANCELLED_STATUSES):
-                return jsonify({
-                    "error": "La livraison doit être programmée dans le futur",
-                    "code": "PAST_DELIVERY_DATE"
-                }), 400
+                return (
+                    jsonify(
+                        {
+                            "error": "La livraison doit être programmée dans le futur",
+                            "code": "PAST_DELIVERY_DATE",
+                        }
+                    ),
+                    400,
+                )
 
     # Check for scheduling conflicts
     if delivery.truck_id and delivery.scheduled_date:
@@ -530,54 +662,76 @@ def update_delivery(delivery_id):
             Delivery.truck_id == delivery.truck_id,
             Delivery.scheduled_date == delivery.scheduled_date,
             Delivery.scheduled_time == delivery.scheduled_time,
-            ~Delivery.status.in_(CANCELLED_STATUSES + ['livrée'])
+            ~Delivery.status.in_(CANCELLED_STATUSES + ["livrée"]),
         ).first()
-        
+
         if clash:
             return jsonify({"error": "Truck already booked for this time"}), 400
-    
+
     # Commit all changes
     try:
         db.session.commit()
-        
+
         # Get the latest history for the response
-        latest_history = DeliveryHistory.query.filter_by(delivery_id=delivery.id)\
-            .order_by(DeliveryHistory.changed_at.desc())\
+        latest_history = (
+            DeliveryHistory.query.filter_by(delivery_id=delivery.id)
+            .order_by(DeliveryHistory.changed_at.desc())
             .first()
-        
+        )
+
         # Prepare response data
         response_data = {
-            'message': 'Livraison mise à jour avec succès',
-            'is_reschedule': is_rescheduling,
-            'delivery': {
-                'id': str(delivery.id),
-                'status': delivery.status,
-                'scheduled_date': delivery.scheduled_date.isoformat() if delivery.scheduled_date else None,
-                'scheduled_time': delivery.scheduled_time.strftime('%H:%M') if delivery.scheduled_time else None,
-                'truck_id': str(delivery.truck_id) if delivery.truck_id else None,
-                'destination': delivery.destination,
-                'notes': delivery.notes,
-                'delayed': delivery.delayed,
-                'last_updated': delivery.last_updated.isoformat() if delivery.last_updated else None,
-                'order_quantities': {str(l.order_id): l.quantity for l in delivery.order_links}
-            }
+            "message": "Livraison mise à jour avec succès",
+            "is_reschedule": is_rescheduling,
+            "delivery": {
+                "id": str(delivery.id),
+                "status": delivery.status,
+                "scheduled_date": (
+                    delivery.scheduled_date.isoformat()
+                    if delivery.scheduled_date
+                    else None
+                ),
+                "scheduled_time": (
+                    delivery.scheduled_time.strftime("%H:%M")
+                    if delivery.scheduled_time
+                    else None
+                ),
+                "truck_id": str(delivery.truck_id) if delivery.truck_id else None,
+                "is_external": delivery.is_external,
+                "external_truck_label": delivery.external_truck_label,
+                "destination": delivery.destination,
+                "notes": delivery.notes,
+                "delayed": delivery.delayed,
+                "last_updated": (
+                    delivery.last_updated.isoformat() if delivery.last_updated else None
+                ),
+                "order_quantities": {
+                    str(l.order_id): l.quantity for l in delivery.order_links
+                },
+            },
         }
-        
+
         # Include previous data if this was a reschedule
-        if delivery.history and len(delivery.history) > 0 and delivery.history[0].change_type == 'reschedule':
-            response_data['previous_data'] = delivery.history[0].previous_data
-        
+        if (
+            delivery.history
+            and len(delivery.history) > 0
+            and delivery.history[0].change_type == "reschedule"
+        ):
+            response_data["previous_data"] = delivery.history[0].previous_data
+
         return jsonify(response_data), 200
-        
+
     except Exception as e:
         db.session.rollback()
         logging.error(f"Error updating delivery {delivery_id}: {str(e)}")
-        return jsonify({'error': 'An error occurred while updating the delivery'}), 500
-@bp.route('/<delivery_id>', methods=['DELETE', 'OPTIONS'])
+        return jsonify({"error": "An error occurred while updating the delivery"}), 500
+
+
+@bp.route("/<delivery_id>", methods=["DELETE", "OPTIONS"])
 @jwt_required()
 def delete_delivery(delivery_id):
-    if request.method == 'OPTIONS':
-        return '', 200
+    if request.method == "OPTIONS":
+        return "", 200
     try:
         logging.debug(f"Request headers: {dict(request.headers)}")
         identity = get_jwt_identity()
@@ -586,15 +740,15 @@ def delete_delivery(delivery_id):
             delivery_uuid = uuid.UUID(delivery_id)
         except Exception:
             return jsonify({"message": "Invalid delivery ID format"}), 400
-            
+
         # Get the delivery with its orders
-        delivery = Delivery.query.options(
-            db.joinedload(Delivery.orders)
-        ).get(delivery_uuid)
-        
+        delivery = Delivery.query.options(db.joinedload(Delivery.orders)).get(
+            delivery_uuid
+        )
+
         if not delivery:
             return jsonify({"message": "Delivery not found"}), 404
-        
+
         # Get all order IDs associated with this delivery
         order_links = DeliveryOrder.query.filter_by(delivery_id=delivery.id).all()
         order_ids = [link.order_id for link in order_links]
@@ -607,32 +761,36 @@ def delete_delivery(delivery_id):
                     order.quantity += link.quantity
                     db.session.add(order)
 
-        
         # For each order, check if it should be reverted to 'en attente'
         for order_id in order_ids:
             order = Order.query.get(order_id)
             if order:
                 # Check if this order has other active deliveries
-                other_deliveries = db.session.query(Delivery).join(
-                    DeliveryOrder, Delivery.id == DeliveryOrder.delivery_id
-                ).filter(
-                    DeliveryOrder.order_id == order_id,
-                    Delivery.id != delivery.id,
-                    ~func.lower(Delivery.status).in_(CANCELLED_STATUSES + ['livrée'])
-                ).count()
-                
+                other_deliveries = (
+                    db.session.query(Delivery)
+                    .join(DeliveryOrder, Delivery.id == DeliveryOrder.delivery_id)
+                    .filter(
+                        DeliveryOrder.order_id == order_id,
+                        Delivery.id != delivery.id,
+                        ~func.lower(Delivery.status).in_(
+                            CANCELLED_STATUSES + ["livrée"]
+                        ),
+                    )
+                    .count()
+                )
+
                 # If no other active deliveries, revert to 'en attente'
-                if other_deliveries == 0 and (order.status or '').lower() != 'livrée':
-                    order.status = 'en attente'
+                if other_deliveries == 0 and (order.status or "").lower() != "livrée":
+                    order.status = "en attente"
                     db.session.add(order)
-        
+
         # Handle the legacy single order_id if it exists
         if delivery.order_id and delivery.order_id not in order_ids:
             legacy_order = Order.query.get(delivery.order_id)
-            if legacy_order and (legacy_order.status or '').lower() != 'livrée':
-                legacy_order.status = 'en attente'
+            if legacy_order and (legacy_order.status or "").lower() != "livrée":
+                legacy_order.status = "en attente"
                 db.session.add(legacy_order)
-        
+
         # Finally, delete the delivery
         db.session.delete(delivery)
         db.session.commit()

--- a/app/routes/schedule.py
+++ b/app/routes/schedule.py
@@ -4,10 +4,11 @@ from app.models import Order, Truck, Delivery
 from app.utils.scheduler import optimize_schedule
 import io, pandas as pd
 
-bp = Blueprint('schedule', __name__, url_prefix='/schedule')
+bp = Blueprint("schedule", __name__, url_prefix="/schedule")
 bp.strict_slashes = False
 
-@bp.route('/deliveries', methods=['GET'])
+
+@bp.route("/deliveries", methods=["GET"])
 @jwt_required()
 def get_schedule():
     """Return the current delivery schedule.
@@ -18,7 +19,7 @@ def get_schedule():
     the frontend can notify the user.
     """
 
-    active_statuses = ['programmé', 'en cours', 'Programmé', 'En cours']
+    active_statuses = ["programmé", "en cours", "Programmé", "En cours"]
 
     # All trucks (to keep empty ones in the result)
     trucks = Truck.query.all()
@@ -29,8 +30,7 @@ def get_schedule():
     # Map truck_id -> schedule item
     # Each order entry will include the quantity scheduled for that delivery
     schedule_map = {
-        t.id: {'truck': str(t.id), 'orders': [], 'load': 0}
-        for t in trucks
+        t.id: {"truck": t.plate_number, "orders": [], "load": 0} for t in trucks
     }
 
     scheduled_order_ids = set()
@@ -39,17 +39,26 @@ def get_schedule():
     for d in deliveries:
         entry = schedule_map.get(d.truck_id)
         if not entry:
-            # Skip deliveries without a valid truck
-            continue
+            if d.is_external:
+                key = f"ext:{d.external_truck_label or 'Externe'}"
+                entry = schedule_map.setdefault(
+                    key,
+                    {
+                        "truck": d.external_truck_label or "Externe",
+                        "orders": [],
+                        "load": 0,
+                    },
+                )
+            else:
+                continue
 
         # Collect orders associated with this delivery with quantities
         links = d.order_links
         legacy_handled = False
         for link in links:
-            entry['orders'].append({
-                'id': str(link.order_id),
-                'quantity': link.quantity
-            })
+            entry["orders"].append(
+                {"id": str(link.order_id), "quantity": link.quantity}
+            )
             scheduled_order_ids.add(link.order_id)
             scheduled_quantity += link.quantity
             if d.order_id and link.order_id == d.order_id:
@@ -59,7 +68,7 @@ def get_schedule():
         if d.order_id and not legacy_handled:
             order = Order.query.get(d.order_id)
             qty = order.quantity if order else 0
-            entry['orders'].append({'id': str(d.order_id), 'quantity': qty})
+            entry["orders"].append({"id": str(d.order_id), "quantity": qty})
             scheduled_order_ids.add(d.order_id)
             scheduled_quantity += qty
 
@@ -67,27 +76,27 @@ def get_schedule():
     schedule = list(schedule_map.values())
 
     # Orders that are not yet planned
-    pending_orders = Order.query.filter_by(status='en attente').all()
+    pending_orders = Order.query.filter_by(status="en attente").all()
     pending_quantity = sum(o.quantity for o in pending_orders)
 
-    daily_limit = current_app.config.get('DAILY_PRODUCTION_LIMIT', 800)
+    daily_limit = current_app.config.get("DAILY_PRODUCTION_LIMIT", 800)
     total_capacity = sum(t.capacity for t in trucks)
 
     stats = {
-        'total_pending_orders': len(scheduled_order_ids) + len(pending_orders),
-        'total_pending_quantity': scheduled_quantity + pending_quantity,
-        'total_trucks': len(trucks),
-        'total_capacity': total_capacity,
-        'daily_limit': daily_limit,
-        'scheduled_orders': len(scheduled_order_ids),
-        'scheduled_quantity': scheduled_quantity,
-        'trucks_utilized': len([s for s in schedule if s['orders']])
+        "total_pending_orders": len(scheduled_order_ids) + len(pending_orders),
+        "total_pending_quantity": scheduled_quantity + pending_quantity,
+        "total_trucks": len(trucks),
+        "total_capacity": total_capacity,
+        "daily_limit": daily_limit,
+        "scheduled_orders": len(scheduled_order_ids),
+        "scheduled_quantity": scheduled_quantity,
+        "trucks_utilized": len([s for s in schedule if s["orders"]]),
     }
 
-    return jsonify({'schedule': schedule, 'stats': stats}), 200
+    return jsonify({"schedule": schedule, "stats": stats}), 200
 
 
-@bp.route('/export', methods=['GET'])
+@bp.route("/export", methods=["GET"])
 @jwt_required()
 def export_schedule():
     from app.models import Order, Truck, Client, Product  # Import here if needed
@@ -100,61 +109,70 @@ def export_schedule():
     products = {str(p.id): p for p in Product.query.all()}
 
     # Regenerate the schedule (same as the planning)
-    daily_limit = current_app.config.get('DAILY_PRODUCTION_LIMIT', 800)
+    daily_limit = current_app.config.get("DAILY_PRODUCTION_LIMIT", 800)
     # Use pending orders only (or all, as needed)
     schedule_result = optimize_schedule(
         [
             {
-                'id': str(o.id),
-                'quantity': o.quantity,
-                'priority': clients[str(o.client_id)].priority_level if str(o.client_id) in clients else 1,
+                "id": str(o.id),
+                "quantity": o.quantity,
+                "priority": (
+                    clients[str(o.client_id)].priority_level
+                    if str(o.client_id) in clients
+                    else 1
+                ),
             }
             for o in Order.query.filter_by(status="Pending").all()
         ],
-        [
-            {
-                'id': str(t.id),
-                'capacity': t.capacity
-            }
-            for t in Truck.query.all()
-        ],
-        daily_limit
+        [{"id": str(t.id), "capacity": t.capacity} for t in Truck.query.all()],
+        daily_limit,
     )
 
     # Build Excel rows: one per assignment
     rows = []
     for sch in schedule_result:
-        truck = trucks.get(sch['truck'])
-        truck_plate = truck.plate_number if truck else sch['truck']
-        for idx, order_id in enumerate(sch['orders'], 1):
+        truck = trucks.get(sch["truck"])
+        truck_plate = truck.plate_number if truck else sch["truck"]
+        for idx, order_id in enumerate(sch["orders"], 1):
             order = orders.get(order_id)
-            if not order: continue
+            if not order:
+                continue
             client = clients.get(str(order.client_id))
             product = products.get(str(order.product_id))
-            
-            rows.append({
-                'Client': client.name if client else str(order.client_id),
-                'Quantité (t)': order.quantity,
-                'Produit': (
-                    f"{product.name} ({product.type})"
-                    if product and product.type else
-                    (product.name if product else "")
-                ),
-                'Date': order.requested_date.strftime('%Y-%m-%d') if order.requested_date else '',
-                'Heure': order.requested_time.strftime('%H:%M') if order.requested_time else '',
-                'Camion': truck_plate
-            })
+
+            rows.append(
+                {
+                    "Client": client.name if client else str(order.client_id),
+                    "Quantité (t)": order.quantity,
+                    "Produit": (
+                        f"{product.name} ({product.type})"
+                        if product and product.type
+                        else (product.name if product else "")
+                    ),
+                    "Date": (
+                        order.requested_date.strftime("%Y-%m-%d")
+                        if order.requested_date
+                        else ""
+                    ),
+                    "Heure": (
+                        order.requested_time.strftime("%H:%M")
+                        if order.requested_time
+                        else ""
+                    ),
+                    "Camion": truck_plate,
+                }
+            )
 
     # Make DataFrame & export to Excel
     df = pd.DataFrame(rows)
     output = io.BytesIO()
-    with pd.ExcelWriter(output, engine='openpyxl') as writer:
-        df.to_excel(writer, index=False, sheet_name='Planning')
+    with pd.ExcelWriter(output, engine="openpyxl") as writer:
+        df.to_excel(writer, index=False, sheet_name="Planning")
     output.seek(0)
 
     return send_file(
         output,
         as_attachment=True,
-        download_name='planning_livraisons.xlsx',
-        mimetype='application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+        download_name="planning_livraisons.xlsx",
+        mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )


### PR DESCRIPTION
## Summary
- allow deliveries to be linked with external trucks
- expose external truck data in delivery API
- show external trucks in schedule API
- update React delivery form with option for external transport

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686459b8ae04832b9d181b7abacb5d63