### PR TITLE
Fix delivery order quantity validation

### DIFF
--- a/app/routes/deliveries.py
+++ b/app/routes/deliveries.py
@@ -120,7 +120,17 @@ def create_delivery():
             order = Order.query.get(oid)
             if not order:
                 return jsonify({"error": f"Order {oid} not found"}), 400
-            total_qty += order.quantity
+
+            qty = order_quantities.get(str(oid))
+            if qty is None:
+                qty = order.quantity
+
+            try:
+                qty = float(qty)
+            except (ValueError, TypeError):
+                return jsonify({"error": f"Invalid quantity for order {oid}"}), 400
+
+            total_qty += qty
         if truck and truck.capacity and total_qty > truck.capacity:
             return jsonify({"error": "Truck capacity exceeded"}), 400
 


### PR DESCRIPTION
## Summary
- ensure truck capacity checks use requested quantity
- show correct available quantity when editing deliveries
- validate edited quantities against available stock

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ab25d69c832b8feecbc986b40549