### PR TITLE
Group orders by delivery

### DIFF
--- a/frontend/src/components/SchedulePage.jsx
+++ b/frontend/src/components/SchedulePage.jsx
@@ -222,35 +222,28 @@ export default function SchedulePage({ autoRefresh = false }) {
     return truck ? truck.plate_number : truckId;
   };
 
-  // Helper: Compose delivery rows (with extra info)
-  const renderDeliveries = (orderEntries) => {
-    // orderEntries may contain just IDs or objects with id/quantity
-    const deliveries = orderEntries.map((entry, idx) => {
+  // Helper: aggregate information for one delivery entry
+  const aggregateInfo = (item) => {
+    const details = item.orders.map((entry) => {
       const orderId = typeof entry === 'string' ? entry : entry.id;
       const qty = typeof entry === 'object' && entry !== null ? entry.quantity : null;
       const order = orders.find(o => o.id === orderId);
       const client = clients.find(c => c.id === order?.client_id);
       const product = products.find(p => p.id === order?.product_id);
       return {
-        idx,
         clientName: client ? client.name : orderId,
         quantity: qty != null ? qty : order?.quantity,
-        requestedDate: order?.requested_date,
-        requestedTime: order?.requested_time?.slice(0,5) || '-', // "HH:MM"
         product: product ? `${product.name}${product.type ? ` (${product.type})` : ''}` : '',
-        orderObj: order
       };
     });
 
-    // Optional: sort deliveries by time or client
-    if (sortBy === 'time') {
-      deliveries.sort((a, b) => (a.requestedTime > b.requestedTime ? 1 : -1));
-    } else if (sortBy === 'client') {
-      deliveries.sort((a, b) => a.clientName.localeCompare(b.clientName));
-    }
-    // Default: order as per assignment (idx)
+    const clientLabel = details.map(d => `${d.clientName} ${d.quantity}T`).join(' - ');
+    const totalQty = details.reduce((sum, d) => sum + (parseFloat(d.quantity) || 0), 0);
+    const productNames = [...new Set(details.filter(d => d.product).map(d => d.product))].join(' - ');
+    const date = item.scheduled_date || '';
+    const time = item.scheduled_time || '-';
 
-    return deliveries;
+    return { clientLabel, totalQty, productNames, date, time };
   };
 
   // Sort the entire planning (schedule array) based on sortBy
@@ -261,24 +254,14 @@ export default function SchedulePage({ autoRefresh = false }) {
     const sorted = [...schedule];
     if (sortBy === 'time') {
       sorted.sort((a, b) => {
-        const aDeliveries = renderDeliveries(a.orders);
-        const bDeliveries = renderDeliveries(b.orders);
-        // Combine date and time for full chronological sorting
-        const aDate = aDeliveries[0]?.requestedDate || '';
-        const bDate = bDeliveries[0]?.requestedDate || '';
-        const aTime = aDeliveries[0]?.requestedTime || '';
-        const bTime = bDeliveries[0]?.requestedTime || '';
-        // ISO format: 'YYYY-MM-DDTHH:MM' for correct string comparison
-        const aDateTime = aDate && aTime ? `${aDate}T${aTime}` : '';
-        const bDateTime = bDate && bTime ? `${bDate}T${bTime}` : '';
+        const aDateTime = (a.scheduled_date || '') + 'T' + (a.scheduled_time || '');
+        const bDateTime = (b.scheduled_date || '') + 'T' + (b.scheduled_time || '');
         return aDateTime.localeCompare(bDateTime);
       });
     } else if (sortBy === 'client') {
       sorted.sort((a, b) => {
-        const aDeliveries = renderDeliveries(a.orders);
-        const bDeliveries = renderDeliveries(b.orders);
-        const aName = aDeliveries[0]?.clientName || '';
-        const bName = bDeliveries[0]?.clientName || '';
+        const aName = aggregateInfo(a).clientLabel;
+        const bName = aggregateInfo(b).clientLabel;
         return aName.localeCompare(bName);
       });
     }
@@ -496,22 +479,24 @@ export default function SchedulePage({ autoRefresh = false }) {
               </TableHead>
               <TableBody>
                 {getSortedSchedule().map((item, idx) => {
-                  const deliveries = renderDeliveries(item.orders);
-                  // Separate row for each delivery, but only show truck for the first row
-                  return deliveries.length === 0 ? (
-                    <TableRow key={idx}>
-                      <TableCell colSpan={6} align="center">Aucune livraison</TableCell>
+                  if (!item.orders || item.orders.length === 0) {
+                    return (
+                      <TableRow key={idx}>
+                        <TableCell colSpan={6} align="center">Aucune livraison</TableCell>
+                      </TableRow>
+                    );
+                  }
+                  const info = aggregateInfo(item);
+                  return (
+                    <TableRow key={idx} style={tableStyles.row}>
+                      <TableCell>{info.clientLabel}</TableCell>
+                      <TableCell>{info.totalQty}</TableCell>
+                      <TableCell>{info.productNames}</TableCell>
+                      <TableCell>{info.date}</TableCell>
+                      <TableCell>{info.time}</TableCell>
+                      <TableCell>{getTruckPlate(item.truck_id) || item.truck}</TableCell>
                     </TableRow>
-                  ) : deliveries.map((d, i) => (
-                    <TableRow key={i} style={tableStyles.row}>
-                      <TableCell>{d.clientName}</TableCell>
-                      <TableCell>{d.quantity}</TableCell>
-                      <TableCell>{d.product}</TableCell>
-                      <TableCell>{d.requestedDate}</TableCell>
-                      <TableCell>{d.requestedTime}</TableCell>
-                      <TableCell>{getTruckPlate(item.truck)}</TableCell>
-                    </TableRow>
-                  ));
+                  );
                 })}
               </TableBody>
             </Table>


### PR DESCRIPTION
## Summary
- aggregate planned deliveries per delivery record
- show grouped orders in SchedulePage

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865459d9b8c832b80a23567c389fdd6